### PR TITLE
Require `lsp-plugins-lv2` >= 1.2.15

### DIFF
--- a/asahi-audio/PKGBUILD
+++ b/asahi-audio/PKGBUILD
@@ -8,7 +8,7 @@ arch=('aarch64')
 url='http://asahilinux.org'
 license=('MIT')
 makedepends=(wireplumber pipewire)
-depends=('wireplumber>=0.4.16' pipewire bankstown lsp-plugins-lv2 speakersafetyd)
+depends=('wireplumber>=0.4.16' pipewire bankstown 'lsp-plugins-lv2>=1.2.15' speakersafetyd)
 source=(
   "asahi-audio-${pkgver}.tar.gz::https://github.com/AsahiLinux/asahi-audio/archive/refs/tags/v${pkgver}.tar.gz"
 )


### PR DESCRIPTION
This makes sure that the speakers don't melt.

See https://github.com/AsahiLinux/docs/wiki/M1-Series-Feature-Support#speakers
> ### Speakers
> The speakers are enabled with separate patches due to a [lsp-plugins bug](https://github.com/lsp-plugins/lsp-dsp-lib/pull/20). The bug causes full-scale artifacts which could potentially damage the speakers. This fix was included in lsp-plugins release [1.0.20](https://github.com/lsp-plugins/lsp-dsp-lib/releases/tag/1.0.20).

The latest `lsp-plugins-lv2` release that contains this `lsp-dsp-lib` is [1.2.14](https://github.com/lsp-plugins/lsp-plugins/releases/tag/1.2.14), see https://github.com/lsp-plugins/lsp-plugins/commit/28db644f934f56ae7f5793ff0037441fef4225a7  (`grep` for `LSP_DSP_LIB_VERSION`).

Meanwhile 1.2.15 got released and is availbe in the ALARM repos already. (contains even never version of the plugins, see https://github.com/lsp-plugins/lsp-plugins/blob/1.2.15/modules.mk#L35)