### PR TITLE
Enable speakers

### DIFF
--- a/linux-asahi/0001-READ-COMMIT-MESSAGE-macaudio-Enable-first-round-of-m.patch
+++ b/linux-asahi/0001-READ-COMMIT-MESSAGE-macaudio-Enable-first-round-of-m.patch
@@ -1,0 +1,82 @@
+From 385ea7b5023486aba7919cec8b6b3f6a843a1013 Mon Sep 17 00:00:00 2001
+From: Hector Martin <marcan@marcan.st>
+Date: Fri, 15 Dec 2023 20:38:32 +0900
+Subject: [PATCH 1/2] READ COMMIT MESSAGE! macaudio: Enable first round of
+ models
+
+Enables j313, j293, j493, j314, j414, j274, j375, j473, j474, j475
+
+*** WARNING FOR DISTRO PACKAGERS WANTING TO APPLY THIS: ***
+*** YOU ABSOLUTELY NEED THIS PATCH IN YOUR LSP-PLUGINS PACKAGE ***
+
+https://github.com/lsp-plugins/lsp-dsp-lib/pull/20
+
+Do NOT enable speakers without that patch, on any model. It can/will
+result in nasty noise that could damage them.
+
+Signed-off-by: Hector Martin <marcan@marcan.st>
+---
+ sound/soc/apple/macaudio.c | 20 ++++++++++++--------
+ 1 file changed, 12 insertions(+), 8 deletions(-)
+
+diff --git a/sound/soc/apple/macaudio.c b/sound/soc/apple/macaudio.c
+index f5b349057a67..d2ced87e88c0 100644
+--- a/sound/soc/apple/macaudio.c
++++ b/sound/soc/apple/macaudio.c
+@@ -1490,23 +1490,27 @@ struct macaudio_platform_cfg macaudio_j180_cfg = {
+ 	false,	AMP_SN012776,	SPKR_1W1T,	false,	10,	-20,
+ };
+ struct macaudio_platform_cfg macaudio_j274_cfg = {
+-	false,	AMP_TAS5770,	SPKR_1W,	false,	20,	-20,
++	true,	AMP_TAS5770,	SPKR_1W,	false,	20,	-20,
+ };
+ 
+ struct macaudio_platform_cfg macaudio_j293_cfg = {
+-	false,	AMP_TAS5770,	SPKR_2W,	true,	15,	-20,
++	true,	AMP_TAS5770,	SPKR_2W,	true,	15,	-20,
+ };
+ 
+ struct macaudio_platform_cfg macaudio_j313_cfg = {
+-	false,	AMP_TAS5770,	SPKR_1W,	true,	10,	-20,
++	true,	AMP_TAS5770,	SPKR_1W,	true,	10,	-20,
+ };
+ 
+-struct macaudio_platform_cfg macaudio_j314_j316_cfg = {
++struct macaudio_platform_cfg macaudio_j314_cfg = {
++	true,	AMP_SN012776,	SPKR_2W1T,	true,	15,	-20,
++};
++
++struct macaudio_platform_cfg macaudio_j316_cfg = {
+ 	false,	AMP_SN012776,	SPKR_2W1T,	true,	15,	-20,
+ };
+ 
+ struct macaudio_platform_cfg macaudio_j37x_j47x_cfg = {
+-	false,	AMP_SN012776,	SPKR_1W,	false,	20,	-20,
++	true,	AMP_SN012776,	SPKR_1W,	false,	20,	-20,
+ };
+ 
+ struct macaudio_platform_cfg macaudio_j413_cfg = {
+@@ -1522,7 +1526,7 @@ struct macaudio_platform_cfg macaudio_j45x_cfg = {
+ };
+ 
+ struct macaudio_platform_cfg macaudio_j493_cfg = {
+-	false,	AMP_SN012776,	SPKR_2W,	true,	15,	-20,
++	true,	AMP_SN012776,	SPKR_2W,	true,	15,	-20,
+ };
+ 
+ struct macaudio_platform_cfg macaudio_fallback_cfg = {
+@@ -1558,9 +1562,9 @@ static const struct of_device_id macaudio_snd_device_id[]  = {
+ 	/* j313    AID4    tas5770     10      2× 1W */
+ 	{ .compatible = "apple,j313-macaudio", .data = &macaudio_j313_cfg },
+ 	/* j314    AID8    sn012776    15      2× 2W+1T */
+-	{ .compatible = "apple,j314-macaudio", .data = &macaudio_j314_j316_cfg },
++	{ .compatible = "apple,j314-macaudio", .data = &macaudio_j314_cfg },
+ 	/* j316    AID9    sn012776    15      2× 2W+1T */
+-	{ .compatible = "apple,j316-macaudio", .data = &macaudio_j314_j316_cfg },
++	{ .compatible = "apple,j316-macaudio", .data = &macaudio_j316_cfg },
+ 	/* j375    AID10   sn012776    15      1× 1W */
+ 	{ .compatible = "apple,j375-macaudio", .data = &macaudio_j37x_j47x_cfg },
+ 	/* j413    AID13   sn012776    15      2× 1W+1T */
+-- 
+2.45.0
+

--- a/linux-asahi/0002-READ-COMMIT-MESSAGE-macaudio-Enable-second-round-of-.patch
+++ b/linux-asahi/0002-READ-COMMIT-MESSAGE-macaudio-Enable-second-round-of-.patch
@@ -1,0 +1,51 @@
+From 6a24102c06c95951ab992e2d41336cc6d4bfdf23 Mon Sep 17 00:00:00 2001
+From: Hector Martin <marcan@marcan.st>
+Date: Fri, 15 Dec 2023 20:40:53 +0900
+Subject: [PATCH 2/2] READ COMMIT MESSAGE! macaudio: Enable second round of
+ models
+
+Enables j316, j413, j415, j416
+
+*** WARNING FOR DISTRO PACKAGERS WANTING TO APPLY THIS: ***
+*** YOU ABSOLUTELY NEED THIS PATCH IN YOUR LSP-PLUGINS PACKAGE ***
+
+https://github.com/lsp-plugins/lsp-dsp-lib/pull/20
+
+Do NOT enable speakers without that patch, on any model. It can/will
+result in nasty noise that could damage them.
+
+Signed-off-by: Hector Martin <marcan@marcan.st>
+---
+ sound/soc/apple/macaudio.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/sound/soc/apple/macaudio.c b/sound/soc/apple/macaudio.c
+index d2ced87e88c0..f347f08b7ad0 100644
+--- a/sound/soc/apple/macaudio.c
++++ b/sound/soc/apple/macaudio.c
+@@ -1506,7 +1506,7 @@ struct macaudio_platform_cfg macaudio_j314_cfg = {
+ };
+ 
+ struct macaudio_platform_cfg macaudio_j316_cfg = {
+-	false,	AMP_SN012776,	SPKR_2W1T,	true,	15,	-20,
++	true,	AMP_SN012776,	SPKR_2W1T,	true,	15,	-20,
+ };
+ 
+ struct macaudio_platform_cfg macaudio_j37x_j47x_cfg = {
+@@ -1514,11 +1514,11 @@ struct macaudio_platform_cfg macaudio_j37x_j47x_cfg = {
+ };
+ 
+ struct macaudio_platform_cfg macaudio_j413_cfg = {
+-	false,	AMP_SN012776,	SPKR_1W1T,	true,	15,	-20,
++	true,	AMP_SN012776,	SPKR_1W1T,	true,	15,	-20,
+ };
+ 
+ struct macaudio_platform_cfg macaudio_j415_cfg = {
+-	false,	AMP_SN012776,	SPKR_2W1T,	true,	15,	-20,
++	true,	AMP_SN012776,	SPKR_2W1T,	true,	15,	-20,
+ };
+ 
+ struct macaudio_platform_cfg macaudio_j45x_cfg = {
+-- 
+2.45.0
+

--- a/linux-asahi/PKGBUILD
+++ b/linux-asahi/PKGBUILD
@@ -28,11 +28,17 @@ options=('!strip')
 source=(
   https://github.com/AsahiLinux/linux/archive/${_commit_id}.tar.gz
   config         # the main kernel config file
+  0001-READ-COMMIT-MESSAGE-macaudio-Enable-first-round-of-m.patch
+  0002-READ-COMMIT-MESSAGE-macaudio-Enable-second-round-of-.patch
 )
 sha256sums=('15e8837a6905324500e7cf7972e6a8b25a21897ae2b8e5003129af885a2edd2f'
-            '9432e63b6c631273d7ef2040703c4fd70f99f16261168dc4e1a9aae2fec2ce99')
+            '9432e63b6c631273d7ef2040703c4fd70f99f16261168dc4e1a9aae2fec2ce99'
+            'd133d00c2198673b5f8a37249ea936a466dc98050a7b6b0767d7a6dfc42d8541'
+            '95408f3b1cc8842e12ffaa3ce41ada149ee32fd5bd2bbafa95449388a37cef7c')
 b2sums=('5a08d3df1d0e1fc274a68f29ab592c790421d58dafa5533b7f526f13c5046d668e0c864b9a71f2c5b736a1890a65ba0877694b11bbde9acf5ff873f7a8a5a167'
-        '4353850ca1b12cd8eb8176b83973274ef802ac5625ad04918d0d90212305b750051cd93b286e45db723aaddd2421cecd133bbb94ae7c5ee56b2d5d5d0d2e072d')
+        '4353850ca1b12cd8eb8176b83973274ef802ac5625ad04918d0d90212305b750051cd93b286e45db723aaddd2421cecd133bbb94ae7c5ee56b2d5d5d0d2e072d'
+        '2e0015cfb2aea1b4bc2da796f4a40c7d9ac21baf08aae572d28ecc4f0f399141072df42acb598176cfb06c6184dadc1ccfbf8a2a8b4e9085759260e800068e26'
+        '2b0481f336dbf33c3909ac16a9b3ab8b425a31a085746730648910a00b8fabf90ba3988e4bb04d9c8801e1b100c6ecba858c191a2fab00c0af51f931c26a515d')
 export KBUILD_BUILD_HOST=archlinux
 export KBUILD_BUILD_USER=$pkgbase
 export KBUILD_BUILD_TIMESTAMP="$(date -Ru${SOURCE_DATE_EPOCH:+d @$SOURCE_DATE_EPOCH})"


### PR DESCRIPTION
With [your updated kernel](https://github.com/AsahiLinux/PKGBUILDs/pull/41) my speakers did not work.
All other packages were installed and up to date from [your pull requests](https://github.com/AsahiLinux/PKGBUILDs/pulls/joske) (`speakersafetyd`, `bankstown`, ` asahi-scripts`, `
uboot-asahi`, `m1n1`, etc.).

After starting `speakersafetyd` (and even after restarting my [J314sAP](https://github.com/AsahiLinux/docs/wiki/Devices)), this is what I was seeing with `journalctl -u speakersafetyd.service`:

```
Mai 14 11:41:10 mkurz-macbook-pro speakersafetyd[6800]: thread 'main' panicked at src/helpers.rs:172:13:
Mai 14 11:41:10 mkurz-macbook-pro speakersafetyd[6800]: Could not lock elem Left Woofer 1 VSENSE Switch. alsa-lib error: Error("snd_ctl_elem_lock",>
Mai 14 11:41:10 mkurz-macbook-pro speakersafetyd[6800]: note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Mai 14 11:41:10 mkurz-macbook-pro speakersafetyd[6800]: WARN  [speakersafetyd] Panic!
```

Now, googling I found [this chat log](https://oftc.irclog.whitequark.org/asahi/2024-02-12#1707762141-1707762277;) which describes the same error:
```
[18:22](https://oftc.irclog.whitequark.org/asahi/2024-02-12#32916743) <milky> I am getting this error when the speakersafetydeamon tries to run
[18:22](https://oftc.irclog.whitequark.org/asahi/2024-02-12#32916744) <milky> Could not lock elem Left Woofer 1 VSENSE Switch. alsa-lib error: Error("snd_ctl_elem_lock", ENOENT)
[18:22](https://oftc.irclog.whitequark.org/asahi/2024-02-12#32916747) <milky> also "Failed to set uclamp"
[18:23](https://oftc.irclog.whitequark.org/asahi/2024-02-12#32916748) <j`ey> milky: youre probably missing the patches that actually enables the speakers see branch: speakers/enablement-READ-COMMIT-MESSAGE
[18:23](https://oftc.irclog.whitequark.org/asahi/2024-02-12#32916749) <j`ey> and for the latter, you need CONFIG_UCLAMP_TASKS
[18:24](https://oftc.irclog.whitequark.org/asahi/2024-02-12#32916752) <j`ey> and UCLAMP_TASK_GROUP
```

So, what caught my interest here is this sentence:

> _**youre probably missing the patches that actually enables the speakers see branch: speakers/enablement-READ-COMMIT-MESSAGE**_

Now, the talk is about this branch here: https://github.com/AsahiLinux/linux/commits/speakers/enablement-READ-COMMIT-MESSAGE
That branch is based on the [`asahi-6.6-12` tag](https://github.com/AsahiLinux/linux/releases/tag/asahi-6.6-12) and contains just two commits (also see [GitHub diff here](https://github.com/AsahiLinux/linux/compare/asahi-6.6-12...speakers/enablement-READ-COMMIT-MESSAGE)):
```
385ea7b50234 READ COMMIT MESSAGE! macaudio: Enable first round of models
6a24102c06c9 READ COMMIT MESSAGE! macaudio: Enable second round of models
```

So... I thought could it be that the Fedora Asahi kernel somehow applies this two commits to enable speakers?
Now, naive as I am, to find out what's different between the original Asahi kernel and the Fedora kernel, I cloned both kernels and diffed them...:
1. Cloned https://gitlab.com/fedora-asahi/kernel-asahi and checked out the [`kernel-6.8.9-403.asahi` tag](https://gitlab.com/fedora-asahi/kernel-asahi/-/commits/kernel-6.8.9-403.asahi/), which seems is the current stable Asahi Fedora remix kernel
2. Cloned https://github.com/AsahiLinux/linux and checked out the [`asahi-6.8.9-5` tag](https://github.com/AsahiLinux/linux/commits/asahi-6.8.9-5/) which is the latest "original" Asahi kernel obviously.

Now, diffing these two kernels on my machine, I can see that the fedora folks applied some fedora specific arm64 patches, which I think are not specific to the Asahi project.
AND of course the `sound/soc/apple/macaudio.c` file differs since the fedora kernel contains the above two commits...
- 2407cad812e6936796574cec6c62921a36ad9a6e ([gitlab](https://gitlab.com/fedora-asahi/kernel-asahi/-/commit/2407cad812e6936796574cec6c62921a36ad9a6e))
- 7fdb0273c72292d3619ef4e77ee515afc3695447 ([gitlab](https://gitlab.com/fedora-asahi/kernel-asahi/-/commit/7fdb0273c72292d3619ef4e77ee515afc3695447))

So obviously to enable speakers we have to apply these two commits as well. So what I did now is to generate two patch files with

```
git format-patch -2 asahi-6.6-12..speakers/enablement-READ-COMMIT-MESSAGE 
```
and make `PKGBUILD` aware of them.

**After re-building the kernel with these patches, I now have audio working on my J314sAP! :partying_face:**

Now, I was thinking there are other Asahi alternatives like [Ubuntu Asahi](https://ubuntuasahi.org/), what do they do about speakers? In their [README](https://github.com/UbuntuAsahi/ubuntu-asahi?tab=readme-ov-file#what-do-i-need-to-do-to-enable-graphics-accelerationsoundwebcam) they state that sound is working out of the box....
Now, let's look at _their_ kernel: https://github.com/UbuntuAsahi/linux/commits/master/
As you can see, high up you find the two audio patches as well! (_"READ COMMIT MESSAGE! macaudio: Enable..."_) - it seems before each kernel release they automatically apply these patches as well! This again confirms my thought that we do have to apply them too...

BTW, just for the record (and my future self), here are links to the fedora kernel spec and the Patchlist.changelog which also mention these two commits in their log:
- https://copr-dist-git.fedorainfracloud.org/cgit/@asahi/kernel/kernel.git/tree/kernel.spec?h=f40
- https://copr-dist-git.fedorainfracloud.org/cgit/@asahi/kernel/kernel.git/tree/Patchlist.changelog?h=f40