### PR TITLE
Add python-packaging to mesa-asahi-edge's makedepends

### DIFF
--- a/mesa-asahi-edge/PKGBUILD
+++ b/mesa-asahi-edge/PKGBUILD
@@ -22,7 +22,7 @@ arch=('aarch64')
 makedepends=('python-mako' 'libxml2' 'libx11' 'xorgproto' 'libdrm' 'libxshmfence' 'libxxf86vm'
              'libxdamage' 'libvdpau' 'libva' 'wayland' 'wayland-protocols' 'zstd' 'elfutils' 'llvm' 'spirv-llvm-translator'
              'libomxil-bellagio' 'libclc' 'clang' 'libglvnd' 'libunwind' 'lm_sensors' 'libxrandr'
-             'systemd' 'valgrind' 'glslang' 'vulkan-icd-loader' 'directx-headers' 'cmake' 'meson' 'python-pycparser')
+             'systemd' 'valgrind' 'glslang' 'vulkan-icd-loader' 'directx-headers' 'cmake' 'meson' 'python-pycparser' 'python-packaging')
 url="https://www.mesa3d.org/"
 license=('custom')
 options=('debug' '!lto')


### PR DESCRIPTION
This is a copy of https://github.com/AsahiLinux/PKGBUILDs/pull/46, to fix error on building mesa-asahi-edge with `makepkg` with Python 3.12:

```
...
Program python3 found: YES (/usr/bin/python3)

mesa-asahi-20240527/meson.build:958:2: ERROR: Problem encountered: Python (3.x) mako module >= 0.8.0 required to build mesa.
```