### PR TITLE
Bump asahi-audio to v2.3 / speakersafetyd to 1.0.1

### DIFF
--- a/asahi-audio/PKGBUILD
+++ b/asahi-audio/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Hector Martin <marcan@marcan.st>
 
 pkgname=asahi-audio
-pkgver=2.2
+pkgver=2.3
 pkgrel=1
 pkgdesc='Linux Userspace Audio Configuration'
 arch=('aarch64')
@@ -12,7 +12,7 @@ depends=('wireplumber>=0.4.16' pipewire bankstown 'lsp-plugins-lv2>=1.2.15' spea
 source=(
   "asahi-audio-${pkgver}.tar.gz::https://github.com/AsahiLinux/asahi-audio/archive/refs/tags/v${pkgver}.tar.gz"
 )
-sha256sums=('bad54b42c82625c989c9142f7a8fe983ec564279d6086e6ae82005d4ef2a4fe8')
+sha256sums=('8131ab45553e8d19a42ee4d0d59730a60d502b05bbfa6ab96519e7ec79b64380')
 
 build() {
   cd "${srcdir}/asahi-audio-${pkgver}"

--- a/speakersafetyd/PKGBUILD
+++ b/speakersafetyd/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: Hector Martin <marcan@marcan.st>
 
 pkgname=speakersafetyd
-pkgver=1.0.0
-commit=7faaaa5a0bd949e993560da82d1594c17b75712c
+pkgver=1.0.1
+commit=3f7e7be539958938df28ec33c59bef81a19c0d60
 pkgrel=1
 pkgdesc='Asahi Linux speaker safety daemon'
 arch=('aarch64')
@@ -12,7 +12,7 @@ license=('MIT')
 source=(
   "speakersafetyd-${commit}.tar.gz::https://github.com/AsahiLinux/speakersafetyd/archive/${commit}.tar.gz"
 )
-sha256sums=('e8ca222ba078eb940997bf47f5cf872296123110d4b31a7e6c3fcea39a7f580f')
+sha256sums=('217c106a41368bf67eea1ffb829bbca067666b4b554a756ff0a7b0bfd3cbd57c')
 
 build() {
   cd "${srcdir}/speakersafetyd-${commit}"


### PR DESCRIPTION
- https://github.com/AsahiLinux/asahi-audio/compare/v2.2...v2.3
- https://github.com/AsahiLinux/speakersafetyd/compare/1.0.0...1.0.1